### PR TITLE
Add more tools

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,17 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+  test:
+    name: Go test coverage check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+    
+    - name: generate test coverage
+      run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 
+    - name: check test coverage
+      uses: vladopajic/go-test-coverage@v2
+      with:
+        config: ./.testcoverage.yml

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           directories: ./...
 
+      - name: Go Staticcheck
+        uses: dominikh/staticcheck-action@v1
+        with:
+          version: "latest"
+          install-go: false
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
-    
+
     - name: generate test coverage
       run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,23 @@ on:
 
 jobs:
 
+  code-check:
+    name: Check formatting and vetting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run the formatter and vetter
+        uses: dell/common-github-actions/go-code-formatter-vetter@main
+        with:
+          directories: ./...
+
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout the code
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -26,3 +39,4 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,54 @@
+# (mandatory) 
+# Path to coverage profile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running 
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list 
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# (optional; but recommended to set) 
+# When specified reported file paths will not contain local prefix in the output.
+local-prefix: "github.com/TafThorne/golang-awaitility"
+
+# Holds coverage thresholds percentages, values should be in range [0-100].
+threshold:
+  # (optional; default 0) 
+  # Minimum coverage percentage required for individual files.
+  file: 85
+
+  # (optional; default 0) 
+  # Minimum coverage percentage required for each package.
+  package: 90
+
+  # (optional; default 0) 
+  # Minimum overall project coverage percentage required.
+  total: 95
+
+# Holds regexp rules which will override thresholds for matched files or packages 
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply 
+# new threshold to it. If project has multiple rules that match same path, 
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `awaitility` package 
+  # (default is 90, as configured above in this example).
+  - path: ^awaitility$
+    threshold: 100
+
+# Holds regexp rules which will exclude matched files or packages 
+# from coverage statistics.
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$    # excludes all protobuf generated files
+
+# File name of go-test-coverage breakdown file, which can be used to 
+# analyze coverage difference.
+breakdown-file-name: ''
+
+diff:
+  # File name of go-test-coverage breakdown file which will be used to 
+  # report coverage difference.
+  base-breakdown-file-name: ''

--- a/awaitility/awaitility.go
+++ b/awaitility/awaitility.go
@@ -5,7 +5,6 @@ package awaitility
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -62,14 +61,14 @@ func Await(pollInterval time.Duration, atMost time.Duration, until func() bool) 
 
 				if timeLeft <= 0 {
 					stackTrace := string(debug.Stack())
-					return errors.New(fmt.Sprintf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace))
+					return fmt.Errorf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace)
 				} else {
 					go untilWrapper(until, resultChan)
 				}
 			}
 		case <-time.After(timeLeft):
 			stackTrace := string(debug.Stack())
-			return errors.New(fmt.Sprintf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace))
+			return fmt.Errorf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace)
 		}
 		time.Sleep(pollInterval)
 	}
@@ -131,7 +130,7 @@ func AwaitBlocking(pollInterval time.Duration, atMost time.Duration, until func(
 
 			if timeLeft <= 0 {
 				stackTrace := string(debug.Stack())
-				return errors.New(fmt.Sprintf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace))
+				return fmt.Errorf("%s: %d ms\n%s", TIMEOUT_ERROR, atMost/time.Millisecond, stackTrace)
 			}
 		}
 

--- a/awaitility/awaitility.go
+++ b/awaitility/awaitility.go
@@ -57,7 +57,7 @@ func Await(pollInterval time.Duration, atMost time.Duration, until func() bool) 
 			if conditionOk {
 				return nil
 			} else {
-				timeLeft = atMost - time.Now().Sub(startTime)
+				timeLeft = atMost - time.Since(startTime)
 
 				if timeLeft <= 0 {
 					stackTrace := string(debug.Stack())
@@ -126,7 +126,7 @@ func AwaitBlocking(pollInterval time.Duration, atMost time.Duration, until func(
 		if until() {
 			return nil
 		} else {
-			timeLeft = atMost - time.Now().Sub(startTime)
+			timeLeft = atMost - time.Since(startTime)
 
 			if timeLeft <= 0 {
 				stackTrace := string(debug.Stack())

--- a/awaitility/awaitility_test.go
+++ b/awaitility/awaitility_test.go
@@ -42,7 +42,7 @@ func TestAwaitFalse(t *testing.T) {
 		return false
 	})
 
-	delta := time.Now().Sub(startTime) / time.Millisecond
+	delta := time.Since(startTime) / time.Millisecond
 
 	if delta > 20 {
 		t.Errorf("Took too long to cancel, took %dms, expected to be under 20ms", delta)
@@ -79,7 +79,7 @@ func TestPassTimeInFunc(t *testing.T) {
 		return true
 	})
 
-	delta := time.Now().Sub(startTime) / time.Millisecond
+	delta := time.Since(startTime) / time.Millisecond
 
 	if delta > 100 {
 		t.Errorf("Took too long to cancel, took %dms, expected to be under 100ms", delta)
@@ -183,7 +183,7 @@ func TestPassTimeInFuncBlocking(t *testing.T) {
 		return true
 	})
 
-	delta := time.Now().Sub(startTime) / time.Millisecond
+	delta := time.Since(startTime) / time.Millisecond
 
 	if delta < 200 {
 		t.Errorf("Took not long enough, took %dms, expected to be over 200ms", delta)
@@ -230,7 +230,7 @@ func TestAwaitBlockingFalse(t *testing.T) {
 		return false
 	})
 
-	delta := time.Now().Sub(startTime) / time.Millisecond
+	delta := time.Since(startTime) / time.Millisecond
 
 	if delta > 20 {
 		t.Errorf("Took too long to cancel, took %dms, expected to be under 20ms", delta)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/TafThorne/golang-awaitility
 
 go 1.23
-
-require github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/TafThorne/golang-awaitility
 
-go 1.16
+go 1.23
 
 require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Continue updating the project by checking there is very high test coverage and start to apply current Go standards (formatting, etc).  Also remove very old or deprecated dependencies if they are not essential.  

By ensuring the test coverage remains high, backwards compatibility with version 1.1.0 can be ensured.  Before any breaking changes are generated I would like to make a v1.2.0 release, using a symantic version number that Go modules can recognise and work with.  